### PR TITLE
Allow amortize params to be zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,13 @@ var amortizationCalc = function(amount, rate, totalTerm, amortizeTerm) {
       monthlyPrincPaid,
       summedAmortize = {};
 
-  /** Calculate monthly interest rate and monthly payment */
+  // Calculate monthly interest rate and monthly payment
   periodInt = (rate / 12) / 100;
   monthlyPayment = amount * (periodInt / (1 - Math.pow(1 + periodInt, -(totalTerm))));
+  // If zero or NaN is returned (i.e. if the rate is 0) calculate the payment without interest
+  monthlyPayment = monthlyPayment || amount / totalTerm;
 
-  /** Calculate the interest, principal, and remaining balance for each period*/
+  // Calculate the interest, principal, and remaining balance for each period
   var i = 0;
   while( i < amortizeTerm) {
     monthlyIntPaid = amount * periodInt;
@@ -53,7 +55,6 @@ var errorCheck = function(opts) {
   for (var key in opts) {
     if (opts.hasOwnProperty(key)) {
       if (typeof opts[key] === 'undefined' || isNaN(parseFloat(opts[key])) || opts[key] < 0) {
-        console.log(opts);
         throw new Error('Loan ' + key + ' must be a non-negative value.');
       }
     }

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,8 @@ var amortize = require('../index.js');
 
 var testVal = amortize({amount: 180000, rate: 4.25, totalTerm: 360, amortizeTerm: 60}),
     testVal2 = amortize({amount: 180000, rate: 4.375, totalTerm: 360, amortizeTerm: 60}),
-    testVal3 = amortize({amount: 0, rate: 4.375, totalTerm: 360, amortizeTerm: 60});
+    testVal3 = amortize({amount: 0, rate: 4.375, totalTerm: 360, amortizeTerm: 60}),
+    testVal4 = amortize({amount: 180000, rate: 0, totalTerm: 360, amortizeTerm: 60});
 
 exports['After 5 years a borrower with a 30 year, $180,000 loan with a 4.25% interest rate will have paid $36583.362108097754 in raw interest'] = function (test) {
   test.equal(testVal.interest, 36583.362108097754);
@@ -34,8 +35,13 @@ exports['After 5 years a borrower with a 30 year, $180,000 loan with a 4.375% in
   test.done();
 };
 
-exports['After 5 years a borrower borrowing nothing will owe nothing'] = function (test) {
+exports['After 5 years a borrower borrowing nothing will owe no interest'] = function (test) {
   test.equal(testVal3.interestRound, 0);
+  test.done();
+};
+
+exports['After 5 years a borrower borrowing without interest will owe no interest'] = function (test) {
+  test.equal(testVal4.interestRound, 0);
   test.done();
 };
 


### PR DESCRIPTION
@ascott1 Currently, the loan amount and interest rate params have to be positive numbers. Passing 0 or below throws an error.

Someone _could_ borrow money with a zero percent interest rate. This PR tells the module to only reject negative values. It will help when amortizing on the fly from user input.
