### PR TITLE
return monthly principal and interest amounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,15 @@ This will return an object containing the interest, principal, balance, and mont
 ```javascript
 { 
   interest: 36583.362108097754,
+  monthlyInterest: 579.9810829318615,
   principal: 16546.146128485594,
+  monthlyPrincipal: 305.5107210111943,
   balance: 163453.85387151438,
   payment: 885.4918039430557,
   interestRound: '36583.36',
+  monthlyInterestRound: '579.98',
   principalRound: '16546.15',
+  monthlyPrincipalRound: '305.51',
   balanceRound: '163453.85',
   paymentRound: '885.49'
 }

--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ var amortizationCalc = function(amount, rate, totalTerm, amortizeTerm) {
     i += 1;
   }
 
+  summedAmortize.monthlyInterest = monthlyIntPaid;
+  summedAmortize.monthlyPrincipal = monthlyPrincPaid;
   summedAmortize.interest = summedInterest;
   summedAmortize.principal = summedPrincipal;
   summedAmortize.balance = amount;

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,16 @@ exports['A borrower with a 30 year, $180,000 loan with a 4.25% interest rate wil
   test.done();
 };
 
+exports['A borrower with a 30 year, $180,000 loan with a 4.25% interest rate will pay $579.98 in interest monthly'] = function (test) {
+  test.equal(testVal.monthlyInterestRound, 579.98);
+  test.done();
+};
+
+exports['A borrower with a 30 year, $180,000 loan with a 4.25% interest rate will pay $305.51 in principal monthly'] = function (test) {
+  test.equal(testVal.monthlyPrincipalRound, 305.51);
+  test.done();
+};
+
 exports['After 5 years a borrower with a 30 year, $180,000 loan with a 4.375% interest rate will have paid $37,694.10 in interest'] = function (test) {
   test.equal(testVal2.interestRound, 37694.10);
   test.done();


### PR DESCRIPTION
## Added
* expose monthly principal + monthly interest amounts for use in the [monthly amounts breakdown](https://github.com/cfpb/owning-a-home/commit/5ae23cd0d5486e69a8d4cd8882f0ed5e242756cd#diff-87728865f2f2c8cae97a1eb94d91a574)

## Review
* @virginiacc 
* @contolini 